### PR TITLE
Fixes #1: removes check for PM context in hook_privmsg()

### DIFF
--- a/src/hexchat_otr.c
+++ b/src/hexchat_otr.c
@@ -239,8 +239,6 @@ int hook_privmsg (char *word[], char *word_eol[], void *userdata)
 	};
 	hexchat_context *query_ctx;
 
-	if (get_current_context_type () != 3) /* Not PM */
-		return HEXCHAT_EAT_NONE;
 	if (!extract_nick (nick, word[1], sizeof(nick)))
 		return HEXCHAT_EAT_NONE;
 


### PR DESCRIPTION
I removed the call to `get_current_context_type` in `hook_privmsg`, which checks for a current PM context, and the `return` if one is not found.  This appears to have been mistakenly copied from `hook_outgoing`.  The original code resulted in non-decrypted messages being received if the PM/query tab did not have focus.