### PR TITLE
Fix channel message receive bug

### DIFF
--- a/src/hexchat_otr.c
+++ b/src/hexchat_otr.c
@@ -219,6 +219,8 @@ int hook_privmsg (char *word[], char *word_eol[], void *userdata)
 	};
 	hexchat_context *query_ctx;
 
+        if (word[3][0] == '#') /* ignore channel message */
+                return HEXCHAT_EAT_NONE;
 	if (!extract_nick (nick, word[1], sizeof(nick)))
 		return HEXCHAT_EAT_NONE;
 


### PR DESCRIPTION
Fixes a bug, introduced by commit SHA: e8f12f944f611a8eb22d255acf84b1e9e389b01, where channel messages are lost when sent from a nick that has an active OTR session with the user.  This is done by ignoring incoming messages if `word[3][0] == '#'` is true, where `word[3]` contains the nick or channel name.  The # character is restricted and cannot be used in nicknames.