### PR TITLE
Use syntax accepted by Python 2 and 3 in Debian Jessie.

### DIFF
--- a/src/makeformats.py
+++ b/src/makeformats.py
@@ -9,7 +9,10 @@ import sys,os,re
 
 lines = map(lambda x: x.strip(),open(sys.argv[1],"r").readlines())
 
-out_dir = sys.argv[2] if len(sys.argv) > 2 or "."
+if len(sys.argv) > 2:
+	out_dir = sys.argv[2]
+else:
+	out_dir = "."
 hdr = open(os.path.join(out_dir, "otr-formats.h"), "w")
 srcx = open(os.path.join(out_dir, "hexchat-formats.c"), "w")
 


### PR DESCRIPTION
Without this change, the following error show up during build:

  File "src/makeformats.py", line 12
    out_dir = sys.argv[2] if len(sys.argv) > 2 or "."
                                                    ^
SyntaxError: invalid syntax