### PR TITLE
Ignore format-nonliteral error in clang

### DIFF
--- a/src/hexchat_otr.c
+++ b/src/hexchat_otr.c
@@ -374,7 +374,9 @@ void printformat (IRC_CTX *ircctx, const char *nick, int lvl, int fnum, ...)
 
 	hexchat_set_context (ph, find_query_ctx);
 
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	if (g_vsnprintf (msg, sizeof(msg), formats[fnum].def, params) < 0)
+#pragma GCC diagnostic pop
 		g_snprintf (msg, sizeof(msg), "internal error parsing error string (BUG)");
 	va_end (params);
 	hexchat_printf (ph, "OTR: %s", s);


### PR DESCRIPTION
While compiling hexchat-otr for FreeBSD 11.x, I received following error:

```make  all-am
/bin/sh ./libtool  --tag=CC   --mode=compile cc -DHAVE_CONFIG_H -I.    -I/usr/local/include -I/usr/local/include/glib-2.0 -Isr/local/include -I/usr/local/include -O2 -g -fstack-protector -fno-strict-aliasing -std=gnu99 -funsigned-char -fstack-protea -Wconversion -Winline -Wno-padded -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror=implicit-functionWerror=init-self -Werror=format=2 -Werror=missing-include-dirs -Werror=date-time -MT src/otr_la-hexchat_otr.lo -MD -MP -MF so src/otr_la-hexchat_otr.lo `test -f 'src/hexchat_otr.c' || echo './'`src/hexchat_otr.c
libtool: compile:  cc -DHAVE_CONFIG_H -I. -I/usr/local/include -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/inclu/include -O2 -g -fstack-protector -fno-strict-aliasing -std=gnu99 -funsigned-char -fstack-protector-strong -fPIC -Wall -Wext -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith Werror=missing-include-dirs -Werror=date-time -MT src/otr_la-hexchat_otr.lo -MD -MP -MF src/.deps/otr_la-hexchat_otr.Tpo -c c/.libs/otr_la-hexchat_otr.o
src/hexchat_otr.c:290:6: warning: no previous prototype for function 'hexchat_plugin_get_info' [-Wmissing-prototypes]
void hexchat_plugin_get_info (char **name, char **desc, char **version, void **reserved)
     ^
src/hexchat_otr.c:297:5: warning: no previous prototype for function 'hexchat_plugin_init' [-Wmissing-prototypes]
int hexchat_plugin_init (hexchat_plugin *plugin_handle,
    ^
src/hexchat_otr.c:328:5: warning: no previous prototype for function 'hexchat_plugin_deinit' [-Wmissing-prototypes]
int hexchat_plugin_deinit (void)
    ^
src/hexchat_otr.c:377:37: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
        if (g_vsnprintf (msg, sizeof(msg), formats[fnum].def, params) < 0)
                                           ^~~~~~~~~~~~~~~~~
3 warnings and 1 error generated.
*** Error code 1
```

Attached diff similar to 12f84706a9f fixes this.

Thanks!