### PR TITLE
add prototypes  (-Werror=missing-prototypes)

### DIFF
--- a/src/hexchat_otr.h
+++ b/src/hexchat_otr.h
@@ -59,6 +59,13 @@ enum
 
 extern hexchat_plugin *ph; /* plugin handle */
 
+int hexchat_plugin_deinit (void);
+int hexchat_plugin_init (hexchat_plugin *plugin_handle,
+                         char **plugin_name,
+                         char **plugin_desc,
+                         char **plugin_version,
+                         char *arg);
+void hexchat_plugin_get_info (char **name, char **desc, char **version, void **reserved);
 void printformat (IRC_CTX *ircctx, const char *nick, int lvl, int fnum, ...);
 
 #define otr_noticest(formatnum, ...) \


### PR DESCRIPTION
Because compilation fails with error :

src/hexchat_otr.c:328:5: error: no previous prototype for ‘hexchat_plugin_deinit’ [-Werror=missing-prototypes]

