### PR TITLE
fix and use enum lvls

### DIFF
--- a/src/hexchat_otr.c
+++ b/src/hexchat_otr.c
@@ -337,12 +337,12 @@ int hexchat_plugin_deinit (void)
 	return 1;
 }
 
-void otr_log(IRC_CTX *server, const char *nick, int level, const char *format, ...)
+void otr_log(IRC_CTX *server, const char *nick, enum lvls level, const char *format, ...)
 {
 	/* TODO: Implement me! */
 }
 
-void printformat (IRC_CTX *ircctx, const char *nick, int lvl, int fnum, ...)
+void printformat (IRC_CTX *ircctx, const char *nick, enum lvls lvl, int fnum, ...)
 {
 	va_list params;
 	va_start (params, fnum);

--- a/src/hexchat_otr.c
+++ b/src/hexchat_otr.c
@@ -337,12 +337,12 @@ int hexchat_plugin_deinit (void)
 	return 1;
 }
 
-void otr_log(IRC_CTX *server, const char *nick, enum lvls level, const char *format, ...)
+void otr_log(IRC_CTX *server, const char *nick, MessageLevel level, const char *format, ...)
 {
 	/* TODO: Implement me! */
 }
 
-void printformat (IRC_CTX *ircctx, const char *nick, enum lvls lvl, int fnum, ...)
+void printformat (IRC_CTX *ircctx, const char *nick, MessageLevel lvl, int fnum, ...)
 {
 	va_list params;
 	va_start (params, fnum);

--- a/src/hexchat_otr.h
+++ b/src/hexchat_otr.h
@@ -52,11 +52,11 @@ struct _FORMAT_REC
 
 typedef struct _FORMAT_REC FORMAT_REC;
 
-enum lvls
+typedef enum
 {
 	MSGLEVEL_CRAP,
 	MSGLEVEL_MSGS
-};
+} MessageLevel;
 
 extern hexchat_plugin *ph; /* plugin handle */
 
@@ -67,7 +67,7 @@ G_MODULE_EXPORT int hexchat_plugin_init (hexchat_plugin *plugin_handle,
                                          char **plugin_version,
                                          char *arg);
 G_MODULE_EXPORT void hexchat_plugin_get_info (char **name, char **desc, char **version, void **reserved);
-void printformat (IRC_CTX *ircctx, const char *nick, enum lvls lvl, int fnum, ...);
+void printformat (IRC_CTX *ircctx, const char *nick, MessageLevel lvl, int fnum, ...);
 
 #define otr_noticest(formatnum, ...) \
 	printformat (NULL, NULL, MSGLEVEL_MSGS, formatnum, ##__VA_ARGS__)

--- a/src/hexchat_otr.h
+++ b/src/hexchat_otr.h
@@ -52,11 +52,11 @@ struct _FORMAT_REC
 
 typedef struct _FORMAT_REC FORMAT_REC;
 
-enum
+enum lvls
 {
 	MSGLEVEL_CRAP,
 	MSGLEVEL_MSGS
-} lvls;
+};
 
 extern hexchat_plugin *ph; /* plugin handle */
 
@@ -67,7 +67,7 @@ G_MODULE_EXPORT int hexchat_plugin_init (hexchat_plugin *plugin_handle,
                                          char **plugin_version,
                                          char *arg);
 G_MODULE_EXPORT void hexchat_plugin_get_info (char **name, char **desc, char **version, void **reserved);
-void printformat (IRC_CTX *ircctx, const char *nick, int lvl, int fnum, ...);
+void printformat (IRC_CTX *ircctx, const char *nick, enum lvls lvl, int fnum, ...);
 
 #define otr_noticest(formatnum, ...) \
 	printformat (NULL, NULL, MSGLEVEL_MSGS, formatnum, ##__VA_ARGS__)

--- a/src/otr.h
+++ b/src/otr.h
@@ -49,7 +49,7 @@
 	otr_log (NULL, NULL, level, format, ##__VA_ARGS__)
 
 void otr_log (IRC_CTX *server, const char *to,
-			  int level, const char *format, ...);
+	      enum lvls level, const char *format, ...);
 
 /* own */
 

--- a/src/otr.h
+++ b/src/otr.h
@@ -49,7 +49,7 @@
 	otr_log (NULL, NULL, level, format, ##__VA_ARGS__)
 
 void otr_log (IRC_CTX *server, const char *to,
-	      enum lvls level, const char *format, ...);
+	      MessageLevel level, const char *format, ...);
 
 /* own */
 


### PR DESCRIPTION
fixes the error:

/usr/bin/ld: src/25a6634@@otr@sha/otr_key.c.o:/home/hexchat-otr/builddir/../src/hexchat_otr.h:59: multiple definition of `lvls'; src/25a6634@@otr@sha/meson-generated_.._hexchat-formats.c.o:/home/hexchat-otr/builddir/../src/hexchat_otr.h:59: first defined here

welcome to gcc 10