### PR TITLE
max message size and header guards

### DIFF
--- a/src/formats.txt
+++ b/src/formats.txt
@@ -3,9 +3,9 @@ kg_failed	Key generation for %s: failed: %s (%s)
 kg_completed	Key generation for %s: completed in %d seconds. Reloading keys...
 kg_aborted_dup	Key generation for %s: aborted. Key generation for %s still in progress.
 kg_aborted_dir	Key generation for %s: aborted, failed to create directory %s: %s
-kg_mkdir	Created directory %s
-kg_pipe	Key generation for %s: error creating pipe: %s
-kg_fork	Key generation for %s: fork() error: %s
+kg_mkdir	created directory %s
+kg_pipe	        Key generation for %s: error creating pipe: %s
+kg_fork	        Key generation for %s: fork() error: %s
 kg_initiated	Key generation for %s: initiated. This might take several minutes or, on some systems, even an hour. If you want to check that something is happening, see if there are two processes of your IRC client.
 kg_exited	Key generation for %s: child terminated for unknown reason
 kg_exitsig	Key generation for %s: child was killed by signal %s
@@ -34,11 +34,11 @@ ops_notify_bug	BUG() in ops_notify
 ops_notify	title: %s prim: %s sec: %s
 ops_display_bug	BUG() in ops_display
 ops_display	msg: %s
-ops_sec	gone %%9secure%%9
-ops_fpcomp	Your peer is not authenticated. To be sure you're talking to the correct person you may have agreed on a pre-shared secret, and you may use the authentication described in %9/otr auth%9. Otherwise you should compare fingerprints in-person or over a secure line (e.g. encrypted messenger) and, subsequently, enter %9/otr trust%9 when you have confirmed their identity. Your fingerprint is: %s. %s's fingerprint: %s
-ops_insec	gone %9insecure%9
-ops_still_reply	still %%9secure%9 (is reply)
-ops_still_no_reply	still %%9secure%9 (is not reply)
+ops_sec	        Channel has gone %%9secure%%9.
+ops_fpcomp	Your peer is not authenticated. To be sure you're talking to the correct person you may have privately agreed on a shared secret. If so, you may use the authentication described in %9/otr auth%9. Otherwise you should compare fingerprints in-person or over a secure line (e.g. encrypted messenger) and, subsequently, enter %9/otr trust%9 when you have confirmed your peer's identity. Your fingerprint is: %s. %s's fingerprint: %s
+ops_insec	Channel has gone %9insecure%9
+ops_still_reply	        still %%9secure%9 (Peer replied)
+ops_still_no_reply	still %%9secure%9 (Peer did not reply)
 ops_log	log msg: %s
 ops_inject	Couldn't inject message from %s for %s: %s
 ops_handle_msg	Message event %s, msg %s
@@ -73,9 +73,9 @@ auth_successful	Authentication successful!
 auth_failed	Authentication failed!
 auth_needenc	You need to establish an OTR session before you can authenticate.
 Commands
-cmd_otr	We're alive
+cmd_otr	        We're alive
 cmd_qnotfound	Failed: Can't get nick and server of current query window. (Or maybe you're doing this in the status window?)
-cmd_auth	First, agree privately on a pre-shared secret with your peer, and then initiate authentication with /otr auth <secret> (or let them initiate). Should you initiate, your peer will be instructed to enter the shared secret as well. Once they have done so the authentication will finish up. If you have both typed in the same secret the authentication should be successful.
+cmd_auth	First, agree privately on a shared secret with your peer, and then initiate authentication with /otr auth <secret> (or let them initiate). Should you initiate, your peer will be instructed to enter the shared secret as well. Once they have done so the authentication will finish up. If you have both typed in the same secret the authentication should be successful.
 cmd_debug_on	Debug mode is on
 cmd_debug_off	Debug mode is off
 cmd_finish	Finished conversation with %s@%s.

--- a/src/hexchat_otr.h
+++ b/src/hexchat_otr.h
@@ -1,3 +1,5 @@
+#ifndef HEX_OTR_H
+#define HEX_OTR_H
 /*
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,3 +92,5 @@ void printformat (IRC_CTX *ircctx, const char *nick, MessageLevel lvl, int fnum,
 #define IRCCTX_ADDR(ircctx) ircctx->address
 #define IRCCTX_NICK(ircctx) ircctx->nick
 #define IRCCTX_FREE(ircctx) g_free (ircctx)
+
+#endif //EOF

--- a/src/otr.h
+++ b/src/otr.h
@@ -1,5 +1,8 @@
-/*
- * Off-the-Record Messaging (OTR) module for the irssi IRC client
+#ifndef OTR_H
+#define OTR_H
+/* 
+ * Off-the-Record Messaging (OTR) module for IRC clients
+ *  *************************************************** 
  * Copyright (C) 2008  Uli Meis <a.sporto+bee@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -54,14 +57,12 @@ void otr_log (IRC_CTX *server, const char *to,
 /* own */
 
 #include "config.h"
-
 #include "otr-formats.h"
 
-/* 
- * maybe this should be configurable?
- * I believe bitlbee has something >500.
- */
-#define OTR_MAX_MSG_SIZE 400
+/* Most IRC servers limit messages to 512 bytes in length, 
+ * including trailing whitespace and the CR-LF terminating characters 
+ * i.e  len( bytes(msg) | <0x20> x ... | <0x0D0A> ) <= 512 bytes */
+#define OTR_MAX_MSG_SIZE 510 //RFC 2812
 
 /* otr protocol id */
 #define PROTOCOLID "IRC"
@@ -151,12 +152,12 @@ struct co_info
 {
 	char *msgqueue; /* holds partially reconstructed base64
 					   messages */
-	IRC_CTX *ircctx; /* irssi server object for this peer */
+	IRC_CTX *ircctx; /* IRC server object for this peer */
 	int received_smp_init; /* received SMP init msg */
 	int smp_failed; /* last SMP failed */
 	char better_msg_two[256]; /* what the second line of the "better"
-					   default query msg should like. Eat it
-					   up when it comes in */
+				     default query msg should like. Eat 
+				     it up when it comes in */
 	int finished; /* true after you've /otr finished */
 };
 
@@ -190,7 +191,6 @@ struct ctxlist_
 };
 
 /* policy list generated from /set otr_policy */
-
 struct plistentry
 {
 	GPatternSpec *namepat;
@@ -205,21 +205,18 @@ IRC_CTX *server_find_address (char *address);
 void otr_status_change (IRC_CTX *ircctx, const char *nick, int event);
 
 /* init stuff */
-
 int otrlib_init (void);
 void otrlib_deinit (void);
 void otr_initops (void);
 void otr_setpolicies (const char *policies, int known);
 
 /* basic send/receive/status stuff */
-
 char *otr_send (IRC_CTX *server, const char *msg, const char *to);
 char *otr_receive (IRC_CTX *server, const char *msg, const char *from);
 int otr_getstatus(IRC_CTX *ircctx, const char *nick);
 ConnContext *otr_getcontext (const char *accname, const char *nick, int create, void *data);
 
 /* user interaction */
-
 void otr_trust (IRC_CTX *server, char *nick, const char *peername);
 void otr_finish (IRC_CTX *server, char *nick, const char *peername, int inquery);
 void otr_auth (IRC_CTX *server, char *nick, const char *peername, const char *question, const char *secret);
@@ -229,7 +226,6 @@ struct ctxlist_ *otr_contexts (void);
 void otr_finishall (void);
 
 /* key/fingerprint stuff */
-
 void keygen_run (const char *accname);
 void keygen_abort (int ignoreidle);
 void key_load (void);
@@ -239,3 +235,5 @@ void otr_writefps (void);
 /* instance tags */
 void instag_load (void);
 void otr_writeinstags (void);
+
+#endif //EOF

--- a/src/otr_key.c
+++ b/src/otr_key.c
@@ -1,5 +1,6 @@
 /*
- * Off-the-Record Messaging (OTR) module for the irssi IRC client
+ * Off-the-Record Messaging (OTR) module for IRC clients
+ *  *************************************************** 
  * Copyright (C) 2008  Uli Meis <a.sporto+bee@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/src/otr_ops.c
+++ b/src/otr_ops.c
@@ -1,5 +1,6 @@
 /*
- * Off-the-Record Messaging (OTR) module for the irssi IRC client
+ * Off-the-Record Messaging (OTR) module for IRC clients
+ *  *************************************************** 
  * Copyright (C) 2008  Uli Meis <a.sporto+bee@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -143,15 +144,12 @@ static void ops_secure (void *opdata, ConnContext *context)
 	 * Let's print out the fingerprints for comparison */
 
 	otrl_privkey_hash_to_human (peerfp,
-								context->active_fingerprint->fingerprint);
+				    context->active_fingerprint->fingerprint);
 
 	otr_notice (coi->ircctx, context->username, TXT_OPS_FPCOMP,
-				otrl_privkey_fingerprint (otr_state,
-										  ownfp,
-										  context->accountname,
-										  PROTOCOLID),
-				context->username,
-				peerfp);
+		    otrl_privkey_fingerprint (otr_state, ownfp,
+					      context->accountname, PROTOCOLID),
+		    context->username, peerfp);
 }
 
 /*
@@ -174,7 +172,7 @@ static void ops_still_secure (void *opdata, ConnContext *context, int is_reply)
 				context->username, is_reply ? TXT_OPS_STILL_REPLY : TXT_OPS_STILL_NO_REPLY);
 }
 
-/*
+/* 
  * Really critical with IRC. 
  * Unfortunately, we can't tell our peer which size to use.
  * (reminds me of MTU determination...)

--- a/src/otr_util.c
+++ b/src/otr_util.c
@@ -1,5 +1,6 @@
 /*
- * Off-the-Record Messaging (OTR) module for the irssi IRC client
+ * Off-the-Record Messaging (OTR) module for IRC clients
+ *  *************************************************** 
  * Copyright (C) 2008  Uli Meis <a.sporto+bee@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This commit modifies the `MAX_OTR_MSG_SIZE` macro to reflect the 512-byte limit imposed by the IRC standard RFC 2812, adds header guards, and cleans up/updates some file commentary. 